### PR TITLE
feat: Agregar reproducción global de canciones

### DIFF
--- a/internal/music/song.go
+++ b/internal/music/song.go
@@ -1,0 +1,24 @@
+package music
+
+type Song struct {
+	ChannelID string
+	UserName  string
+	ID        string
+	VideoID   string
+	Title     string
+	VideoURL  string
+}
+
+type PkgSong struct {
+	data Song
+	v    *VoiceInstance
+}
+
+func globalPlay(songSig chan PkgSong) {
+	for {
+		select {
+		case song := <-songSig:
+			go song.v.PlayQueue(song.data)
+		}
+	}
+}


### PR DESCRIPTION
Se ha añadido la funcionalidad de reproducción global de canciones en el paquete music. Se ha creado la estructura PkgSong para encapsular los datos de la canción y la instancia de voz asociada. Además, se ha implementado la función globalPlay para manejar la reproducción global de canciones mediante un canal de señales.