### PR TITLE
feat: Agregar funciones para recuperar variables de entorno adicionales

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,8 @@ import (
 	"os"
 )
 
+var config *Config
+
 type Config struct {
 	DiscordBotToken string
 	ChannelID       string
@@ -36,4 +38,24 @@ func NewConfig() (*Config, error) {
 		BotID:           botID,
 	}
 	return cfg, nil
+}
+
+func GetDiscordToken() string {
+	return config.DiscordBotToken
+}
+
+func GetChannelID() string {
+	return config.ChannelID
+}
+
+func GetServerID() string {
+	return config.ServerID
+}
+
+func GetBotRoleID() string {
+	return config.BotRoleID
+}
+
+func GetBotID() string {
+	return config.BotID
 }


### PR DESCRIPTION
Este PR agrega funciones adicionales al paquete config para recuperar variables de entorno adicionales. Ahora se pueden obtener el ID del canal, el ID del servidor, el ID del rol del bot y el ID del bot utilizando las nuevas funciones agregadas.

**Cambios detallados:**

- Se han añadido funciones para recuperar el ID del canal, el ID del servidor, el ID del rol del bot y el ID del bot desde la estructura de configuración.
- Cada función devuelve el valor correspondiente de la variable de entorno.